### PR TITLE
Remove login count console.log to prevent undefined loginInfo exception

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -51,8 +51,6 @@ chrome.storage.sync.get({
         return;
     }
 
-    console.log('Fun fact of the developer console nerd: You have logged in to Jira at least ' + loginResult.loginInfo.loginCount + ' times!');
-
     // Check page if content changed (for AJAX pages)
     $(document).on('DOMNodeInserted', function() {
         if ((new Date()).getTime() - lastRefresh >= 250) {


### PR DESCRIPTION
### Ticket
Link to ticket: **No linked ticket**

### What has been done
- Removed the console.log since the loginInfo object is no longer returned in the API.

### How to test
- Checkout PR
- Load extension into Chrome
- Acknowledge a new cross branch PR now has the placeholder markup again.