### PR TITLE
Change the title target for the new github layout

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -202,7 +202,7 @@ function handlePrCreatePage() {
     }
     body.attr('jira-loading', 1);
 
-    var title = $('div.commitish-suggester > button[aria-label="Choose a head branch"] > span.js-select-button').html();
+    var title = $('.range-cross-repo-pair .js-menu-target .css-truncate-target:eq(3)').html();
     var ticketUrl = '**No linked ticket**';
     var ticketDescription = '...';
     var acceptanceList = '';


### PR DESCRIPTION
### Ticket
Link to ticket: **No linked ticket**

Due to a change in github's layout. Resolving the source branch name failed resulting in no auto-filled title.

### What has been done
- Changed the CSS selector for the source branch.

### How to test
- Checkout PR
- Load extension into Chrome
- Acknowledge a new cross branch PR now has the auto filled title again.