### PR TITLE
Allow for using *.jira.com as domain

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,9 @@
         "activeTab",
         "storage",
         "https://*.atlassian.net/",
-        "http://*.atlassian.net/"
+        "https://*.jira.com/",
+        "http://*.atlassian.net/",
+        "http://*.jira.com/"
     ],
 
     "background": {


### PR DESCRIPTION
Some JIRA customers are set up on `domain.jira.com` and not on `domain.atlassian.com`. This PR helps them use the extension.