### PR TITLE
Fix Issue title selection

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "GitHub Jira Integration",
-    "version": "1.2.2",
+    "version": "1.2.3",
 
     "description": "This extension shows contents of linked tasks from Jira in Github",
 

--- a/src/content.js
+++ b/src/content.js
@@ -267,7 +267,7 @@ function handleCommitsTitle() {
 }
 
 async function handlePrPage() {
-    const titleEl = document.querySelector('h1 > span.js-issue-title');
+    const titleEl = document.querySelector('h1 > .js-issue-title');
     const insertedJiraDataEl = document.querySelector('#insertedJiraData');
     const partialDiscussionHeaderEl = document.querySelector('#partial-discussion-header');
     if (!titleEl || insertedJiraDataEl) {


### PR DESCRIPTION
`<span>` was renamed to `<bdi>`, so we're keeping it simple, selecting on class only with this change.

This fixes #47 